### PR TITLE
Small fixes to make it easier to start

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,2 +1,4 @@
-{:deps
- {com.googlecode.lanterna/lanterna {:mvn/version "3.1.1"}}}
+{:paths ["src"]
+ :deps {com.googlecode.lanterna/lanterna {:mvn/version "3.1.1"}}
+
+ :aliases {:run {:main-opts ["-m" "vee.main"]}}}

--- a/src/vee/main.clj
+++ b/src/vee/main.clj
@@ -719,11 +719,11 @@
              :dirty? false
              :pending-close-delims []}))
 
-(defn main [_]
+(defn -main [& args]
   (with-open [screen (.createScreen (DefaultTerminalFactory.))]
     ;; TODO probably want to addResizeListener to redraw on resize
     (.startScreen screen)
-    (loop [state (initial-state (last *command-line-args*))]
+    (loop [state (initial-state (last args))]
       (draw state screen)
       (when-let [state* (handle-input state (.readInput screen))]
         (recur state*)))))

--- a/src/vee/main.clj
+++ b/src/vee/main.clj
@@ -1,4 +1,4 @@
-(ns main
+(ns vee.main
   (:require
    [clojure.string :as str])
   (:import


### PR DESCRIPTION
- Avoid single segment namespaces; they can cause a bunch of problems and are best avoided
- Rename `main` to `-main` so it can be started properly with `clojure -M:run <file>` and later if you choose you can add a `(:gen-class)` to the namespace declaration and it will aot compile to support starting via `java -jar vee.main`, or later graalvm nativeimage.
- Add a `:run` alias so you can start it properly with the clojure CLI tools
- Switch to explicit args passed to main instead of `*command-line-args*` which are mainly meant for simple scripts without a `-main`.